### PR TITLE
feat(client): update routing to use workspace code in URL and refacto…

### DIFF
--- a/apps/client/src/App.tsx
+++ b/apps/client/src/App.tsx
@@ -7,7 +7,7 @@ function App() {
     <BrowserRouter>
       <Routes>
         <Route path="/" element={<LandingPage />} />
-        <Route path="/dashboard" element={<DashBoard/>} />
+        <Route path="/workspace/:workspaceCode" element={<DashBoard/>} />
       </Routes>
     </BrowserRouter>
   )

--- a/apps/client/src/pages/DashBoard.tsx
+++ b/apps/client/src/pages/DashBoard.tsx
@@ -1,8 +1,9 @@
-import { useLocation } from 'react-router-dom';
+
+import { useParams } from "react-router-dom";
 
 function DashBoard() {
-    const location = useLocation();
-    const {workSpaceCode} = location.state || {};
+  
+    const { workspaceCode } = useParams();
   return (
     <div className="min-h-screen bg-gray-50 p-6 md:p-10">
       <div className="max-w-4xl mx-auto">
@@ -13,7 +14,7 @@ function DashBoard() {
           <div className="flex items-center">
             <span className="text-gray-600 font-medium">Workspace Code:</span>
             <span className="ml-2 px-3 py-1 bg-blue-100 text-blue-800 rounded-md font-mono">
-              {workSpaceCode || "No workspace code provided"}
+              {workspaceCode || "No workspace code provided"}
             </span>
           </div>
         </div>

--- a/apps/client/src/pages/LandingPage.tsx
+++ b/apps/client/src/pages/LandingPage.tsx
@@ -126,7 +126,7 @@ const LandingPage = () => {
 
       console.log("Workspace created with name:", finalWorkspaceName);
       setShowWorkspaceModal(false);
-      navigate("/dashboard", { state: { workSpaceCode: finalWorkspaceName } });
+      navigate(`/workspace/${finalWorkspaceName}`);
     } catch (error) {
       console.error("Error creating workspace:", error);
     }
@@ -148,13 +148,13 @@ const LandingPage = () => {
         { headers: { Authorization: `Bearer ${token}` } }
       );
       console.log("joined WorkSpace:", workspaceName);
-      navigate("/dashboard", { state: { workSpaceCode: workspaceName } });
+      navigate(`/workspace/${workspaceName}`);
     } catch (error) {
       // Type check the error as an AxiosError
       if (axios.isAxiosError(error)) {
         if (error.response?.status === 400) {
           alert("You are already a member of this workspace!");
-          navigate("/dashboard", { state: { workSpaceCode: workspaceName } });
+          navigate(`/workspace/${workspaceName}`);
         } else {
           console.error("Error joining workspace:", error);
         }
@@ -169,9 +169,7 @@ const LandingPage = () => {
     
     setSelectedWorkspace(selectedWorkspaceName);
     if (selectedWorkspaceName) {
-      navigate("/dashboard", {
-        state: { workSpaceCode: selectedWorkspaceName },
-      });
+      navigate(`/workspace/${selectedWorkspaceName}`);
     }
   };
 


### PR DESCRIPTION
This pull request includes changes to the routing and parameter handling for workspace codes in the `apps/client` application. The most important changes involve updating the routes and modifying how workspace codes are passed and accessed.

Routing updates:

* [`apps/client/src/App.tsx`](diffhunk://#diff-c0a15737e3a0b2a722ff38f56a0e8f8663051553603c0e8d53c30f2daf8dac25L10-R10): Updated the route for the dashboard to use a dynamic workspace code in the URL path.

Parameter handling updates:

* [`apps/client/src/pages/DashBoard.tsx`](diffhunk://#diff-ba397a1c545ac88b7cd4a404c5db1c8d545027c7a37c1ce966faa6c2f9e51a92L1-R6): Replaced the use of `useLocation` with `useParams` to access the workspace code from the URL parameters.
* [`apps/client/src/pages/DashBoard.tsx`](diffhunk://#diff-ba397a1c545ac88b7cd4a404c5db1c8d545027c7a37c1ce966faa6c2f9e51a92L16-R17): Updated the display logic to use the `workspaceCode` parameter from `useParams` instead of `workSpaceCode` from the location state.

Navigation updates:

* [`apps/client/src/pages/LandingPage.tsx`](diffhunk://#diff-944ae8890d15f4afd3ee636340f394751c7e2f7492e46a81f022769d1ef490b2L129-R129): Changed the navigation logic to use the updated route with the workspace code as a URL parameter instead of passing it through the location state. [[1]](diffhunk://#diff-944ae8890d15f4afd3ee636340f394751c7e2f7492e46a81f022769d1ef490b2L129-R129) [[2]](diffhunk://#diff-944ae8890d15f4afd3ee636340f394751c7e2f7492e46a81f022769d1ef490b2L151-R157) [[3]](diffhunk://#diff-944ae8890d15f4afd3ee636340f394751c7e2f7492e46a81f022769d1ef490b2L172-R172)…r DashBoard to retrieve it from params