### PR TITLE
feat(client):enhance task creation with authentication

### DIFF
--- a/apps/client/index.html
+++ b/apps/client/index.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="/vite.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Vite + React + TS</title>
+    <title>PixBay</title>
   </head>
   <body>
     <div id="root"></div>

--- a/apps/server/src/controllers/taskController.js
+++ b/apps/server/src/controllers/taskController.js
@@ -68,7 +68,7 @@ export const getProjectTasks = async (req, res) => {
     const email = emailAddresses?.[0]?.emailAddress;
 
     // Find user by email
-    const user = await prisma.user.findUnique({
+    const user = await prisma.user.findFirst({
       where: { email:email},
     });
 


### PR DESCRIPTION
This pull request includes several changes to the `apps/client` and `apps/server` directories, focusing on updating the project title, integrating authentication for task creation, and modifying the task fetching logic. The most important changes are listed below:

### Client-side updates:

* [`apps/client/index.html`](diffhunk://#diff-58dee80f294fd6db4b6582fd46f3cadb1de67ca1ed2211677a730a32eeadf4eaL7-R7): Updated the document title from "Vite + React + TS" to "PixBay".
* [`apps/client/src/components/KanbanBoard.tsx`](diffhunk://#diff-01342d9d7d35a27b5f3a06661832b85a656fd7fa1580d7848aced1ca32fdb733R6): Integrated authentication by importing `useAuth` from `@clerk/clerk-react` and using the `getToken` method to include an authorization header in the task creation request. [[1]](diffhunk://#diff-01342d9d7d35a27b5f3a06661832b85a656fd7fa1580d7848aced1ca32fdb733R6) [[2]](diffhunk://#diff-01342d9d7d35a27b5f3a06661832b85a656fd7fa1580d7848aced1ca32fdb733R313-R351)

### Server-side updates:

* [`apps/server/src/controllers/taskController.js`](diffhunk://#diff-0a39ba1c78758f8badd0b727a2027ba50ecdf868216a66851f30aa7c76cf2f43L71-R71): Changed the Prisma query method from `findUnique` to `findFirst` for fetching the user by email.