### PR TITLE
feat(client): implement task fetching in KanbanBoard with authentication

### DIFF
--- a/apps/client/src/components/KanbanBoard.tsx
+++ b/apps/client/src/components/KanbanBoard.tsx
@@ -312,6 +312,7 @@ const AddTaskModal: React.FC<AddTaskModalProps> = ({
   });
   const { getToken } = useAuth();
 
+  //create task endpoint 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
     try {
@@ -500,12 +501,36 @@ const KanbanBoard: React.FC<KanbanBoardProps> = ({ projectId }) => {
   const [tasks, setTasks] = useState<Task[]>(dummyTasks);
   const [darkMode, setDarkMode] = useState<boolean>(true);
   const [isAddModalOpen, setIsAddModalOpen] = useState(false);
+  const { getToken } = useAuth();
 
-  
+  const fetchTasks = async () => {
+    if (!projectId) return;
+    
+    try {
+      const token = await getToken();
+      const response = await axios.get(
+        `http://localhost:5000/api/tasks/task/${projectId}`,
+        {
+          headers: { Authorization: `Bearer ${token}` },
+        }
+      );
+      
+      if (response.data) {
+        console.log("Fetched tasks:", response.data);
+        setTasks(response.data);
+      }
+    } catch (error) {
+      console.error("Failed to fetch tasks:", error);
+      if (axios.isAxiosError(error)) {
+        console.error("Error details:", error.response?.data);
+      }
+    }
+  };
 
   useEffect(() => {
     if (projectId) {
       console.log("Project id from kanban board page ", projectId);
+      fetchTasks();
     }
   }, [projectId]);
 

--- a/apps/server/src/routes/taskRoutes.js
+++ b/apps/server/src/routes/taskRoutes.js
@@ -5,6 +5,6 @@ import authMiddleware from '../middleware/authMiddleware.js';
 const router = express.Router();
 
 router.post('/create',authMiddleware, createTask);        
-router.get('/project/:projectId',authMiddleware, getProjectTasks); 
+router.get('/task/:projectId',authMiddleware, getProjectTasks); 
 
 export default router;


### PR DESCRIPTION
This pull request includes several changes to the Kanban board feature in the client application and an update to the task routes in the server application. The changes focus on adding task fetching functionality and updating the task endpoint.

### Kanban Board Enhancements:
* Added a `fetchTasks` function to retrieve tasks from the server based on `projectId` using an authorization token.
* Included a call to `fetchTasks` within the `useEffect` hook to fetch tasks when the `projectId` changes.

### Task Endpoint Update:
* Updated the task route in the server to use `/task/:projectId` instead of `/project/:projectId` for fetching project tasks.