### PR TITLE
feat(rateLimiter): add rate limiting middleware for project creation …

### DIFF
--- a/apps/server/package.json
+++ b/apps/server/package.json
@@ -20,6 +20,7 @@
     "cors": "^2.8.5",
     "dotenv": "^16.5.0",
     "express": "^5.1.0",
+    "express-rate-limit": "^7.5.0",
     "nodemon": "^3.1.9",
     "peer": "^1.0.2",
     "socket.io": "^4.8.1"

--- a/apps/server/src/middleware/rateLimiter.js
+++ b/apps/server/src/middleware/rateLimiter.js
@@ -1,0 +1,9 @@
+import rateLimit from "express-rate-limit";
+
+const projectPostLimiter = rateLimit({
+  windowMs: 15 * 60 * 1000, // 15 minutes
+  max: 5, // limit each IP to 10 requests per windowMs
+  message: "Too many project creation attempts from this IP, please try again later.",
+});
+
+export default projectPostLimiter;

--- a/apps/server/src/routes/projectRoutes.js
+++ b/apps/server/src/routes/projectRoutes.js
@@ -5,11 +5,12 @@ import {
   getWorkspaceProjects,
 } from "../controllers/projectController.js";
 import authMiddleware from "../middleware/authMiddleware.js";
+import projectPostLimiter from "../middleware/rateLimiter.js"; 
 
 const router = express.Router();
 
 // POST /api/projects - Create new project
-router.post("/", authMiddleware, createProject);
+router.post("/", projectPostLimiter, authMiddleware, createProject);
 
 // GET /api/projects/workspace/{workspaceName} - Get workspace projects
 router.get("/workspace/:workspaceName", authMiddleware, getWorkspaceProjects);

--- a/package-lock.json
+++ b/package-lock.json
@@ -1110,6 +1110,7 @@
         "cors": "^2.8.5",
         "dotenv": "^16.5.0",
         "express": "^5.1.0",
+        "express-rate-limit": "^7.5.0",
         "nodemon": "^3.1.9",
         "peer": "^1.0.2",
         "socket.io": "^4.8.1"
@@ -6980,6 +6981,20 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/express-rate-limit": {
+      "version": "7.5.0",
+      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-7.5.0.tgz",
+      "integrity": "sha512-eB5zbQh5h+VenMPM3fh+nw1YExi5nMr6HUCR62ELSP11huvxm/Uir1H1QEyTkk5QX6A58pX6NmaTMceKZ0Eodg==",
+      "engines": {
+        "node": ">= 16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/express-rate-limit"
+      },
+      "peerDependencies": {
+        "express": "^4.11 || 5 || ^5.0.0-beta.1"
       }
     },
     "node_modules/fast-deep-equal": {


### PR DESCRIPTION
This pull request introduces rate limiting for project creation requests in the server application to enhance security and prevent abuse. The changes include adding a new dependency, creating a rate limiter middleware, and integrating it into the project routes.

### Rate Limiting Implementation:

* [`apps/server/package.json`](diffhunk://#diff-fafe51f68c0409784dd523adb04b10cb09fe3b7d48c7646c325fecab5fb4ebd2R23): Added the `express-rate-limit` package as a new dependency to enable rate limiting functionality.
* [`apps/server/src/middleware/rateLimiter.js`](diffhunk://#diff-b9626bf11107ae5b6561835638a920828ae129ad4d5c5d14683e62b12f4cbeaaR1-R9): Created a new middleware using `express-rate-limit` to limit project creation requests to 5 per 15-minute window per IP address, with a custom error message for exceeding the limit.

### Integration with Routes:

* [`apps/server/src/routes/projectRoutes.js`](diffhunk://#diff-e5ef078052d48075256c8b867d471bd80623a74962912641fae14458d5fa9bf9R8-R13): Imported the `projectPostLimiter` middleware and applied it to the `POST /api/projects` route to enforce rate limiting for project creation requests.…requests